### PR TITLE
Jenkins plugin installation generated dependency cycles.

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -18,7 +18,7 @@ define jenkins::plugin($version=0) {
         ensure  => directory,
         owner   => $user,
         group   => $group,
-        require => [Package["jenkins"]]];
+        require => [Package["jenkins"]];
     }
   }
 


### PR DESCRIPTION
This PR ensures that jenkins package is installed before applying plugins. The plugin used to depend on both User and Group - jenkins and it did create those in an if statement (if not present)
